### PR TITLE
Query optimization for sorted sideloads

### DIFF
--- a/lib/active_graph_extensions/node/query/query_proxy_eager_loading.rb
+++ b/lib/active_graph_extensions/node/query/query_proxy_eager_loading.rb
@@ -41,15 +41,50 @@ module ActiveGraphExtensions
 
         def query_from_association_tree
           previous_with_vars = defalut_previous_with_vars
-          with_associations_tree.paths.inject(query_as(identity).with(base_query_with_vars)) do |query, path|
-            with_association_query_part(query, path, previous_with_vars).tap do
-              previous_with_vars << var_fix(path_name(path), :collection)
-            end
+
+          sorted_association_paths.inject(query_as(identity).with(base_query_with_vars)) do |query, path|
+            result = with_association_query_part(query, path, previous_with_vars)
+            previous_with_vars << var_fix(path_name(path), :collection)
+            path_name(path) == @early_pagination_path ? apply_early_order_skip_limit(result) : result
           end
         end
 
         def defalut_previous_with_vars
           @with_vars&.dup || []
+        end
+
+        def sorted_association_paths
+          return with_associations_tree.paths if skip_order?
+
+          priority, remaining = priority_paths
+          @early_pagination_path = find_early_pagination_path(priority)
+          priority + remaining
+        end
+
+        def find_early_pagination_path(priority)
+          return nil if skip_order? || priority.blank?
+
+          path_name(priority.last)
+        end
+
+        def priority_paths
+          ordered_names = path_names.select { |name| order_clause_for_query(name).present? }
+
+          with_associations_tree.paths.partition do |path|
+            name = path_name(path)
+            ordered_names.any? { |ordered_name| ordered_name == name || ordered_name.start_with?("#{name}.") }
+          end
+        end
+
+        def apply_early_order_skip_limit(query)
+          @pagination_applied = true
+          query_from_chain(@postponed_chain, apply_order_from_spec(query), identity).break
+        end
+
+        def apply_order_from_spec(query)
+          query.order(
+            (@order_spec || []).flat_map { |key, order_specs| order_specs.map(&method(:order_clause).curry.call(key)) }
+          )
         end
 
         def base_query_with_vars
@@ -93,11 +128,11 @@ module ActiveGraphExtensions
         end
 
         def before_pluck(query)
-          return query if skip_order? && !include_with_path_length?
-          base_query = query.order(
-            (@order_spec || []).flat_map { |key, order_specs| order_specs.map(&method(:order_clause).curry.call(key)) }
-          )
-          query_from_chain(@postponed_chain, base_query, identity)
+          return query if (skip_order? || @pagination_applied) && !include_with_path_length?
+
+          base_query = apply_order_from_spec(query)
+          remaining_chain = @pagination_applied ? @postponed_chain.select { |link| link.clause == :order } : @postponed_chain
+          query_from_chain(remaining_chain, base_query, identity)
         end
 
         def node_aliase_for_collection(key, order_spec)
@@ -119,7 +154,7 @@ module ActiveGraphExtensions
         CLAUSES_TO_POSTPONE = %i[limit order skip].freeze
 
         def include_with_path_length?(path = @with_associations_tree)
-          path.present? && (path.rel_length.present? || path.any? { |_, val| include_with_path_length?(val) })
+          !path.nil? && (path.rel_length.present? || path.any? { |_, val| include_with_path_length?(val) })
         end
 
         def chain

--- a/lib/active_graph_extensions/node/query/query_proxy_eager_loading.rb
+++ b/lib/active_graph_extensions/node/query/query_proxy_eager_loading.rb
@@ -56,24 +56,24 @@ module ActiveGraphExtensions
         def sorted_association_paths
           return with_associations_tree.paths if skip_order?
 
-          priority, remaining = priority_paths
+          priority, remaining = sort_paths
           @early_pagination_path = find_early_pagination_path(priority)
           priority + remaining
         end
 
-        def find_early_pagination_path(priority)
-          return nil if skip_order? || priority.blank?
-
-          path_name(priority.last)
-        end
-
-        def priority_paths
+        def sort_paths
           ordered_names = path_names.select { |name| order_clause_for_query(name).present? }
 
           with_associations_tree.paths.partition do |path|
             name = path_name(path)
             ordered_names.any? { |ordered_name| ordered_name == name || ordered_name.start_with?("#{name}.") }
           end
+        end
+
+        def find_early_pagination_path(priority_paths)
+          return nil if skip_order? || priority_paths.blank?
+
+          path_name(priority_paths.last)
         end
 
         def apply_early_order_skip_limit(query)

--- a/spec/e2e/eager_loading_order_spec.rb
+++ b/spec/e2e/eager_loading_order_spec.rb
@@ -1,0 +1,309 @@
+require 'spec_helper'
+
+describe 'Eager Loading with Ordering' do
+  before do
+    clear_model_memory_caches
+    log_queries!
+  end
+
+  before do
+    stub_node_class('Person') do
+      property :name
+
+      has_many :in, :posts, type: :posts
+      has_one :out, :role, type: :role
+      has_many :out, :knows, model_class: 'Person', type: nil
+
+    end
+
+    stub_node_class('Post') do
+      property :name
+
+      has_one :out, :owner, origin: :posts, model_class: 'Person'
+      has_many :in, :comments, type: :comments
+    end
+
+    stub_node_class('Comment') do
+      property :text
+
+      has_one :out, :post, origin: :comments, model_class: 'Post'
+    end
+
+    stub_node_class('Role') do
+      property :name
+    end
+  end
+
+  describe 'sorted_association_paths order logic' do
+    def sorted_path_names(query)
+      query.send(:sorted_association_paths).map { |path| path.map(&:name).join('.') }
+    end
+
+    it 'returns correct order for two sideloads and one sort param' do
+      query = Person.all.with_ordered_associations(['knows', 'posts'], { 'posts' => ['name'] })
+      expect(sorted_path_names(query)).to eq(['posts', 'knows'])
+    end
+
+    it 'returns correct order for two sideloads and no sort params' do
+      query = Person.all.with_ordered_associations('posts.comments', {})
+      expect(sorted_path_names(query)).to eq(['posts', 'posts.comments'])
+    end
+
+    it 'returns correct order for two sideloads and two sort params' do
+      query = Person.all.with_ordered_associations('posts.comments', { 'posts' => ['name'], 'posts.comments' => ['text'] })
+      expect(sorted_path_names(query)).to eq(['posts', 'posts.comments'])
+    end
+
+    it 'returns correct order for three sideloads, two sort params' do
+      query = Person.all.with_ordered_associations(['knows', 'posts.comments'], { 'posts' => ['name'], 'posts.comments' => ['text'] })
+      expect(sorted_path_names(query)).to eq(['posts', 'posts.comments', 'knows'])
+    end
+  end
+
+  describe 'sideloads with ordering' do
+    let!(:alice) { Person.create(name: 'Alice') }
+    let!(:bob) { Person.create(name: 'Bob') }
+    let!(:charlie) { Person.create(name: 'Charlie') }
+
+    let!(:post_alice) { Post.create(name: 'Zebra', owner: alice) }
+    let!(:post_alice2) { Post.create(name: 'Yacht', owner: alice) }
+    let!(:post_bob) { Post.create(name: 'Apple', owner: bob) }
+    let!(:post_charlie) { Post.create(name: 'Mango', owner: charlie) }
+
+    context 'single sideload' do
+      it 'loads associations in a single query' do
+        expect_queries(1) do
+          Person.all.with_ordered_associations('posts', { 'posts' => ['name'] }).map(&:posts)
+        end
+      end
+
+      it 'returns all person records with their posts loaded' do
+        results = Person.all.with_ordered_associations('posts', { 'posts' => ['name'] }).to_a
+        expect(results.map(&:name)).to eq(%w[Bob Charlie Alice])
+
+        alice_result = results.find { |p| p.name == 'Alice' }
+        expect(alice_result.posts.map(&:name)).to eq(%w[Yacht Zebra])
+      end
+    end
+
+    context 'miltiple sideloads' do
+      let!(:comment_alice) { Comment.create(text: 'Comment on First', post: post_alice) }
+      let!(:comment_bob) { Comment.create(text: 'Comment on Second', post: post_bob) }
+
+      it 'loads nested associations in a single query' do
+        expect_queries(1) do
+          Person.all.with_ordered_associations('posts.comments', { 'posts' => ['name'] }).each do |person|
+            person.posts.each { |post| post.comments.to_a }
+          end
+        end
+      end
+
+      it 'returns correct nested data' do #TODO: not sure if this is needed
+        results = Person.all.with_ordered_associations('posts.comments', { 'posts' => ['name'] }).to_a
+
+        alice_result = results.find { |p| p.name == 'Alice' }
+        expect(alice_result.posts.to_a.first.comments.map(&:text)).to include('Comment on First')
+
+        bob_result = results.find { |p| p.name == 'Bob' }
+        expect(bob_result.posts.to_a.first.comments.map(&:text)).to include('Comment on Second')
+      end
+    end
+  end
+
+  describe 'correct sideloads ordering with skip and limit' do
+    let!(:alice) { Person.create(name: 'Alice') }
+    let!(:bob) { Person.create(name: 'Bob') }
+    let!(:charlie) { Person.create(name: 'Charlie') }
+
+    # Post names control the ORDER BY on collection:
+    # Bob's first post (Apple) < Charlie's first post (Mango) < Alice's first post (Zebra)
+    let!(:post_alice) { Post.create(name: 'Zebra', owner: alice) }
+    let!(:post_bob) { Post.create(name: 'Apple', owner: bob) }
+    let!(:post_charlie) { Post.create(name: 'Mango', owner: charlie) }
+
+    it 'orders main results by sideloaded association property' do
+      results = Person.all
+        .with_ordered_associations('posts', { 'posts' => ['name'] })
+
+      expect(results.map(&:name)).to eq(%w[Bob Charlie Alice])
+    end
+
+    it 'applies limit after sideload ordering' do
+      results = Person.all
+        .with_ordered_associations('posts', { 'posts' => ['name'] })
+        .limit(2)
+
+      expect(results.map(&:name)).to eq(%w[Bob Charlie])
+    end
+
+    it 'applies skip and limit after sideload ordering' do
+      results = Person.all
+        .with_ordered_associations('posts', { 'posts' => ['name'] })
+        .skip(1).limit(1)
+
+      expect(results.map(&:name)).to eq(%w[Charlie])
+    end
+
+    it 'preserves sideloaded associations after skip/limit' do
+      results = Person.all
+        .with_ordered_associations('posts', { 'posts' => ['name'] })
+        .skip(0).limit(2)
+
+      results.each do |person|
+        expect(person.posts.to_a).not_to be_empty
+      end
+    end
+  end
+
+  describe 'multiple sideloads with order' do
+    let!(:role_admin) { Role.create(name: 'Admin') }
+    let!(:role_user) { Role.create(name: 'User') }
+    let!(:role_guest) { Role.create(name: 'Guest') }
+
+    let!(:alice) { Person.create(name: 'Alice', role: role_admin) }
+    let!(:bob) { Person.create(name: 'Bob', role: role_user) }
+    let!(:charlie) { Person.create(name: 'Charlie', role: role_guest) }
+
+    let!(:post_b) { Post.create(name: 'Apple', owner: bob) }
+
+    context 'when three sideloads with two orders' do
+      let!(:post_a) { Post.create(name: 'Apple', owner: alice) }
+      let!(:post_c) { Post.create(name: 'Banana', owner: charlie) }
+
+      it 'returns correctly ordered data' do
+        alice.knows << charlie
+        bob.knows << alice
+
+        results = Person.all
+          .with_ordered_associations(['posts', 'role', 'knows'], {
+            'posts' => ['name'],
+            'knows' => ['name']
+          }).to_a
+
+        # Should be ordered by posts.name: Alice (Apple), Bob (Apple), Charlie (Banana)
+        # For Alice and Bob (same post name), order by knows.name: Bob (knows Alice), Alice (knows Charlie)
+        expect(results.map(&:name)).to eq(['Bob', 'Alice', 'Charlie'])
+
+        bob_result = results[0]
+        alice_result = results[1]
+        charlie_result = results[2]
+
+        expect(bob_result.posts.map(&:name)).to eq(['Apple'])
+        expect(bob_result.knows.map(&:name)).to eq(['Alice'])
+        expect(bob_result.role.name).to eq('User')
+
+        expect(alice_result.posts.map(&:name)).to eq(['Apple'])
+        expect(alice_result.knows.map(&:name)).to eq(['Charlie'])
+        expect(alice_result.role.name).to eq('Admin')
+        
+        expect(charlie_result.posts.map(&:name)).to eq(['Banana'])
+        expect(charlie_result.knows).to be_empty
+        expect(charlie_result.role.name).to eq('Guest')
+      end
+    end
+
+    context 'when two sideloads with one order and limit clause' do
+      let!(:post_a) { Post.create(name: 'Zebra', owner: alice) }
+
+      it 'returns correctly ordered data' do
+        expect_queries(1) do
+          results = Person.all
+            .with_ordered_associations(['posts', 'role'], { 'posts' => ['name'] })
+            .limit(1).to_a
+
+          expect(results.length).to eq(1)
+          first_res = results.first
+          expect(first_res.name).to eq('Bob')
+          expect(first_res.posts.map(&:name)).to eq(['Apple'])
+          expect(first_res.role.name).to eq('User')
+        end
+      end
+    end
+  end
+
+  describe 'without order spec' do
+    let!(:alice) { Person.create(name: 'Alice') }
+    let!(:post) { Post.create(name: 'Post-1', owner: alice) }
+
+    it 'loads associations without reordering paths' do
+      expect_queries(1) do
+        Person.all.with_ordered_associations('posts', {}).each do |person|
+          person.posts.to_a
+        end
+      end
+    end
+
+    it 'returns all data correctly' do
+      results = Person.all.with_ordered_associations('posts', {}).to_a
+      expect(results.first.posts.map(&:name)).to eq(['Post-1'])
+    end
+
+    it 'does not interfere with skip/limit' do
+      Person.create(name: 'Bob')
+      results = Person.all.with_ordered_associations('posts', {}).limit(1).to_a
+      expect(results.length).to eq(1)
+    end
+  end
+
+  describe 'descending order on sideloaded association' do
+    let!(:alice) { Person.create(name: 'Alice') }
+    let!(:bob) { Person.create(name: 'Bob') }
+    let!(:charlie) { Person.create(name: 'Charlie') }
+
+    let!(:post_alice) { Post.create(name: 'Zebra', owner: alice) }
+    let!(:post_bob) { Post.create(name: 'Apple', owner: bob) }
+    let!(:post_charlie) { Post.create(name: 'Mango', owner: charlie) }
+
+    it 'orders main results by sideloaded property descending' do
+      results = Person.all
+        .with_ordered_associations('posts', { 'posts' => ['name DESC'] })
+        .to_a
+
+      # DESC post name order: Alice (Zebra), Charlie (Mango), Bob (Apple)
+      expect(results.map(&:name)).to eq(%w[Alice Charlie Bob])
+    end
+
+    it 'applies skip/limit with descending order' do
+      results = Person.all
+        .with_ordered_associations('posts', { 'posts' => ['name DESC'] })
+        .limit(2).to_a
+
+      # DESC post name order, limit 2: Alice (Zebra), Charlie (Mango)
+      expect(results.map(&:name)).to eq(%w[Alice Charlie])
+    end
+  end
+
+  describe 'variable length relationship with ordering' do
+    let!(:alice) { Person.create(name: 'Alice') }
+    let!(:friend1) { Person.create(name: 'Friend-1', knows: friend2) }
+    let!(:friend2) { Person.create(name: 'Friend-2') }
+
+    before { alice.knows << friend1 }
+
+    let!(:post) { Post.create(name: 'Post-1', owner: alice) }
+
+    it 'loads variable length associations with ordering in a single query' do
+      expect_queries(1) do
+        results = Person.all
+          .with_ordered_associations(['knows*', 'posts'], { 'posts' => ['name'] })
+          .to_a
+
+        alice_result = results.find { |p| p.name == 'Alice' }
+        expect(alice_result.posts.to_a).not_to be_empty
+        expect(alice_result.knows.to_a).not_to be_empty
+      end
+    end
+
+    it 'orders Persons by their first post name even with rel_length present' do
+      bob = Person.create(name: 'Bob')
+      alice_post1 = Post.create(name: 'Zebra', owner: alice)
+      alice_post2 = Post.create(name: 'Yak', owner: alice)
+      bob_post = Post.create(name: 'Apple', owner: bob)
+      results = Person.all
+        .with_ordered_associations(['knows*', 'posts'], { 'posts' => ['name'] })
+        .limit(2).to_a
+
+      expect(results.map(&:name)).to eq(['Bob', 'Alice'])
+    end
+  end
+end

--- a/spec/e2e/eager_loading_order_spec.rb
+++ b/spec/e2e/eager_loading_order_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe 'Eager Loading with Ordering' do
   before do
     clear_model_memory_caches
-    log_queries!
   end
 
   before do
@@ -98,7 +97,7 @@ describe 'Eager Loading with Ordering' do
         end
       end
 
-      it 'returns correct nested data' do #TODO: not sure if this is needed
+      it 'returns correct nested data' do
         results = Person.all.with_ordered_associations('posts.comments', { 'posts' => ['name'] }).to_a
 
         alice_result = results.find { |p| p.name == 'Alice' }

--- a/spec/e2e/eager_loading_order_spec.rb
+++ b/spec/e2e/eager_loading_order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Eager Loading with Ordering' do
@@ -12,7 +14,6 @@ describe 'Eager Loading with Ordering' do
       has_many :in, :posts, type: :posts
       has_one :out, :role, type: :role
       has_many :out, :knows, model_class: 'Person', type: nil
-
     end
 
     stub_node_class('Post') do
@@ -39,8 +40,8 @@ describe 'Eager Loading with Ordering' do
     end
 
     it 'returns correct order for two sideloads and one sort param' do
-      query = Person.all.with_ordered_associations(['knows', 'posts'], { 'posts' => ['name'] })
-      expect(sorted_path_names(query)).to eq(['posts', 'knows'])
+      query = Person.all.with_ordered_associations(%w[knows posts], { 'posts' => ['name'] })
+      expect(sorted_path_names(query)).to eq(%w[posts knows])
     end
 
     it 'returns correct order for two sideloads and no sort params' do
@@ -49,12 +50,14 @@ describe 'Eager Loading with Ordering' do
     end
 
     it 'returns correct order for two sideloads and two sort params' do
-      query = Person.all.with_ordered_associations('posts.comments', { 'posts' => ['name'], 'posts.comments' => ['text'] })
+      query = Person.all.with_ordered_associations('posts.comments',
+                                                   { 'posts' => ['name'], 'posts.comments' => ['text'] })
       expect(sorted_path_names(query)).to eq(['posts', 'posts.comments'])
     end
 
     it 'returns correct order for three sideloads, two sort params' do
-      query = Person.all.with_ordered_associations(['knows', 'posts.comments'], { 'posts' => ['name'], 'posts.comments' => ['text'] })
+      query = Person.all.with_ordered_associations(['knows', 'posts.comments'],
+                                                   { 'posts' => ['name'], 'posts.comments' => ['text'] })
       expect(sorted_path_names(query)).to eq(['posts', 'posts.comments', 'knows'])
     end
   end
@@ -85,7 +88,7 @@ describe 'Eager Loading with Ordering' do
       end
     end
 
-    context 'miltiple sideloads' do
+    context 'multiple sideloads' do
       let!(:comment_alice) { Comment.create(text: 'Comment on First', post: post_alice) }
       let!(:comment_bob) { Comment.create(text: 'Comment on Second', post: post_bob) }
 
@@ -122,35 +125,25 @@ describe 'Eager Loading with Ordering' do
 
     it 'orders main results by sideloaded association property' do
       results = Person.all
-        .with_ordered_associations('posts', { 'posts' => ['name'] })
+                      .with_ordered_associations('posts', { 'posts' => ['name'] })
 
       expect(results.map(&:name)).to eq(%w[Bob Charlie Alice])
     end
 
     it 'applies limit after sideload ordering' do
       results = Person.all
-        .with_ordered_associations('posts', { 'posts' => ['name'] })
-        .limit(2)
+                      .with_ordered_associations('posts', { 'posts' => ['name'] })
+                      .limit(2)
 
       expect(results.map(&:name)).to eq(%w[Bob Charlie])
     end
 
     it 'applies skip and limit after sideload ordering' do
       results = Person.all
-        .with_ordered_associations('posts', { 'posts' => ['name'] })
-        .skip(1).limit(1)
+                      .with_ordered_associations('posts', { 'posts' => ['name'] })
+                      .skip(1).limit(1)
 
       expect(results.map(&:name)).to eq(%w[Charlie])
-    end
-
-    it 'preserves sideloaded associations after skip/limit' do
-      results = Person.all
-        .with_ordered_associations('posts', { 'posts' => ['name'] })
-        .skip(0).limit(2)
-
-      results.each do |person|
-        expect(person.posts.to_a).not_to be_empty
-      end
     end
   end
 
@@ -174,14 +167,14 @@ describe 'Eager Loading with Ordering' do
         bob.knows << alice
 
         results = Person.all
-          .with_ordered_associations(['posts', 'role', 'knows'], {
-            'posts' => ['name'],
-            'knows' => ['name']
-          }).to_a
+                        .with_ordered_associations(%w[posts role knows], {
+                                                     'posts' => ['name'],
+                                                     'knows' => ['name']
+                                                   }).to_a
 
         # Should be ordered by posts.name: Alice (Apple), Bob (Apple), Charlie (Banana)
         # For Alice and Bob (same post name), order by knows.name: Bob (knows Alice), Alice (knows Charlie)
-        expect(results.map(&:name)).to eq(['Bob', 'Alice', 'Charlie'])
+        expect(results.map(&:name)).to eq(%w[Bob Alice Charlie])
 
         bob_result = results[0]
         alice_result = results[1]
@@ -194,7 +187,7 @@ describe 'Eager Loading with Ordering' do
         expect(alice_result.posts.map(&:name)).to eq(['Apple'])
         expect(alice_result.knows.map(&:name)).to eq(['Charlie'])
         expect(alice_result.role.name).to eq('Admin')
-        
+
         expect(charlie_result.posts.map(&:name)).to eq(['Banana'])
         expect(charlie_result.knows).to be_empty
         expect(charlie_result.role.name).to eq('Guest')
@@ -207,8 +200,9 @@ describe 'Eager Loading with Ordering' do
       it 'returns correctly ordered data' do
         expect_queries(1) do
           results = Person.all
-            .with_ordered_associations(['posts', 'role'], { 'posts' => ['name'] })
-            .limit(1).to_a
+                          .with_ordered_associations(%w[posts role], { 'posts' => ['name'] })
+                          .limit(1)
+                          .to_a
 
           expect(results.length).to eq(1)
           first_res = results.first
@@ -255,8 +249,8 @@ describe 'Eager Loading with Ordering' do
 
     it 'orders main results by sideloaded property descending' do
       results = Person.all
-        .with_ordered_associations('posts', { 'posts' => ['name DESC'] })
-        .to_a
+                      .with_ordered_associations('posts', { 'posts' => ['name DESC'] })
+                      .to_a
 
       # DESC post name order: Alice (Zebra), Charlie (Mango), Bob (Apple)
       expect(results.map(&:name)).to eq(%w[Alice Charlie Bob])
@@ -264,8 +258,9 @@ describe 'Eager Loading with Ordering' do
 
     it 'applies skip/limit with descending order' do
       results = Person.all
-        .with_ordered_associations('posts', { 'posts' => ['name DESC'] })
-        .limit(2).to_a
+                      .with_ordered_associations('posts', { 'posts' => ['name DESC'] })
+                      .limit(2)
+                      .to_a
 
       # DESC post name order, limit 2: Alice (Zebra), Charlie (Mango)
       expect(results.map(&:name)).to eq(%w[Alice Charlie])
@@ -276,16 +271,15 @@ describe 'Eager Loading with Ordering' do
     let!(:alice) { Person.create(name: 'Alice') }
     let!(:friend1) { Person.create(name: 'Friend-1', knows: friend2) }
     let!(:friend2) { Person.create(name: 'Friend-2') }
+    let!(:post_yak) { Post.create(name: 'Yak', owner: alice) }
 
     before { alice.knows << friend1 }
-
-    let!(:post) { Post.create(name: 'Post-1', owner: alice) }
 
     it 'loads variable length associations with ordering in a single query' do
       expect_queries(1) do
         results = Person.all
-          .with_ordered_associations(['knows*', 'posts'], { 'posts' => ['name'] })
-          .to_a
+                        .with_ordered_associations(['knows*', 'posts'], { 'posts' => ['name'] })
+                        .to_a
 
         alice_result = results.find { |p| p.name == 'Alice' }
         expect(alice_result.posts.to_a).not_to be_empty
@@ -293,16 +287,19 @@ describe 'Eager Loading with Ordering' do
       end
     end
 
-    it 'orders Persons by their first post name even with rel_length present' do
-      bob = Person.create(name: 'Bob')
-      alice_post1 = Post.create(name: 'Zebra', owner: alice)
-      alice_post2 = Post.create(name: 'Yak', owner: alice)
-      bob_post = Post.create(name: 'Apple', owner: bob)
-      results = Person.all
-        .with_ordered_associations(['knows*', 'posts'], { 'posts' => ['name'] })
-        .limit(2).to_a
+    context 'ordering Person records by their first post name' do
+      let!(:bob) { Person.create(name: 'Bob') }
+      let!(:post_zebra) { Post.create(name: 'Zebra', owner: alice) }
+      let!(:post_apple) { Post.create(name: 'Apple', owner: bob) }
 
-      expect(results.map(&:name)).to eq(['Bob', 'Alice'])
+      it 'orders Person records even with rel_length present' do
+        results = Person.all
+                        .with_ordered_associations(['knows*', 'posts'], { 'posts' => ['name'] })
+                        .limit(2)
+                        .to_a
+
+        expect(results.map(&:name)).to eq(%w[Bob Alice])
+      end
     end
   end
 end

--- a/spec/e2e/eager_loading_order_spec.rb
+++ b/spec/e2e/eager_loading_order_spec.rb
@@ -65,11 +65,11 @@ describe 'Eager Loading with Ordering' do
     let!(:charlie) { Person.create(name: 'Charlie') }
 
     let!(:post_alice) { Post.create(name: 'Zebra', owner: alice) }
-    let!(:post_alice2) { Post.create(name: 'Yacht', owner: alice) }
     let!(:post_bob) { Post.create(name: 'Apple', owner: bob) }
     let!(:post_charlie) { Post.create(name: 'Mango', owner: charlie) }
 
     context 'single sideload' do
+      let!(:post_alice2) { Post.create(name: 'Yacht', owner: alice) }
       it 'loads associations in a single query' do
         expect_queries(1) do
           Person.all.with_ordered_associations('posts', { 'posts' => ['name'] }).map(&:posts)


### PR DESCRIPTION
### Problem
When multiple sideloads are requested with sorting parameters, the generated Cypher query was not optimal: the ORDER BY, SKIP, and LIMIT clauses were applied at the very end, after all sideloads were traversed. This could lead to inefficient queries, especially when only some associations require sorting.

### Solution

- This PR changes the query-building logic to:
- Order Sideloads by Sorting Param: Sideloads with sorting parameters are traversed first, in the order of their sort keys, followed by sideloads without sorting.
- Apply ORDER BY, SKIP, LIMIT Early: The ORDER BY, SKIP, and LIMIT clauses are now applied immediately after the last sideload that has a sorting parameter, rather than at the end of the query.
- Preserve Eager Loading: All associations are still eagerly loaded, but the main result set is now correctly paginated and ordered before loading additional, unsorted sideloads.

### Results

- In the generated Cypher, sideloads with sorting params appear before those without.
- ORDER BY, SKIP, and LIMIT are applied after the last sorted sideload, not at the end.
- All tests verify correct result ordering, pagination, and eager loading.